### PR TITLE
Bugfix: accidentally set the default ewalderrortolerance to 1e-5 earl…

### DIFF
--- a/interfaces/interface_OpenMM.py
+++ b/interfaces/interface_OpenMM.py
@@ -32,7 +32,7 @@ class OpenMMTheory:
                  periodic=False, charmm_periodic_cell_dimensions=None, customnonbondedforce=False,
                  periodic_nonbonded_cutoff=12, dispersion_correction=True,
                  switching_function_distance=10,
-                 ewalderrortolerance=1e-5, PMEparameters=None,
+                 ewalderrortolerance=5e-4, PMEparameters=None,
                  delete_QM1_MM1_bonded=False, applyconstraints_in_run=False,
                  constraints=None, restraints=None, frozen_atoms=None, fragment=None,
                  autoconstraints='HBonds', hydrogenmass=1.5, rigidwater=True):


### PR DESCRIPTION
…ier which slows simulations quite a lot. ASH default is now 5e-4, same as OpenMM default