### PR TITLE
Update

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -104,12 +104,13 @@ from ash.interfaces.interface_PyMBE import PyMBETheory
 
 # MM: external and internal
 from ash.interfaces.interface_OpenMM import OpenMMTheory, OpenMM_MD, OpenMM_MDclass, OpenMM_Opt, OpenMM_Modeller, \
-     OpenMM_box_equilibration, write_nonbonded_FF_for_ligand, solvate_small_molecule, small_molecule_parameterizor, \
+     OpenMM_box_equilibration, write_nonbonded_FF_for_ligand, solvate_small_molecule, small_molecule_parameterizer, \
         OpenMM_metadynamics, Gentle_warm_up_MD, check_gradient_for_bad_atoms, get_free_energy_from_biasfiles, \
         free_energy_from_bias_array,metadynamics_plot_data, merge_pdb_files
 
-#TODO: Temporary alias, to be deleted
+#TODO: Temporary aliases, to be deleted
 OpenMM_box_relaxation = OpenMM_box_equilibration
+small_molecule_parameterizor=small_molecule_parameterizer
 
 from ash.modules.module_MM import NonBondedTheory, UFFdict, UFF_modH_dict, LJCoulpy, coulombcharge, LennardJones, \
     LJCoulombv2, LJCoulomb, MMforcefield_read

--- a/functions/functions_elstructure.py
+++ b/functions/functions_elstructure.py
@@ -1089,18 +1089,18 @@ def num_core_electrons(elems):
 #Check if electrons pairs in element list are less than numcores. Reduce numcores if so.
 #Using even number of electrons
 def check_cores_vs_electrons(elems,numcores,charge):
-    print("numcores:", numcores)
-    print("charge:", charge)
+    print("Checking whether number of cores should be reduced")
     numelectrons = int(nucchargelist(elems) - charge)
     #Reducing numcores if fewer active electron pairs than numcores.
     core_electrons = num_core_electrons(elems)
-    print("core_electrons:", core_electrons)
+    print("Number of core electrons:", core_electrons)
     valence_electrons = (numelectrons - core_electrons)
     electronpairs = int(valence_electrons / 2)
+    print("Number of total electrons :", numelectrons)
+    print("Number of valence electrons :", valence_electrons )
+    print("Number of valence electron pairs :", electronpairs )
     if electronpairs  < numcores:
-        print("Number of total electrons :", numelectrons)
-        print("Number of valence electrons :", valence_electrons )
-        print("Number of valence electron pairs :", electronpairs )
+        print(f"Number of electron pairs ({electronpairs}) less than number of cores ({numcores})")
         if isodd(electronpairs):
             if electronpairs > 1:
                 #Changed from subtracting 1 to 3 after DLPNO-CC of NaH calculation failed (MB16-43)
@@ -1109,9 +1109,10 @@ def check_cores_vs_electrons(elems,numcores,charge):
                 numcores=electronpairs
         else:
             numcores=electronpairs
+        print("Changing number of cores to be approximately equal to number of electron pairs")
     if numcores == 0:
         numcores=1
-    print("Setting numcores to:", numcores)
+    print("Number of cores will be:", numcores)
     return numcores
 
 

--- a/interfaces/interface_CFour.py
+++ b/interfaces/interface_CFour.py
@@ -51,9 +51,11 @@ class CFourTheory:
         self.EXTERN_POT='OFF' #Pointcharge potential off by default
         self.DBOC=DBOC
         self.FIXGEOM='OFF' #Off by default. May be turned on by run-method
+        self.BRUECKNER='OFF'
         #Overriding default
         #self.basis='SPECIAL' is preferred (element-specific basis definitions) but can be overriden like this
         if 'BASIS' in cfouroptions: self.basis=cfouroptions['BASIS']
+        if 'BRUECKNER' in cfouroptions: self.BRUECKNER=cfouroptions['BRUECKNER']
         if 'CALC' in cfouroptions: self.CALC=cfouroptions['CALC']
         if 'MEMORY' in cfouroptions: self.memory=cfouroptions['MEMORY']
         if 'MEM_UNIT' in cfouroptions: self.memory_unit=cfouroptions['MEM_UNIT']
@@ -92,6 +94,7 @@ class CFourTheory:
         print("SCF_MAXCYC:", self.scf_maxcyc)
         print("LINEQ_CONV:", self.lineq_conv)
         print("CC_MAXCYC:", self.cc_maxcyc)
+        print("BRUECKNER:",self.BRUECKNER)
         print("SYMMETRY:", self.symmetry)
         print("HFSTABILITY:", self.stabilityanalysis)
         
@@ -359,7 +362,7 @@ REF={self.reference},CHARGE={charge},MULT={mult},{self.frozencore_string}\n\
 MEM_UNIT={self.memory_unit},MEMORY={self.memory},SCF_MAXCYC={self.scf_maxcyc}\n\
 GUESS={self.guessoption},PROP={self.propoption},CC_PROG={self.cc_prog},ABCDTYPE={self.ABCDTYPE}\n\
 SCF_CONV={self.scf_conv},EXTERN_POT={self.EXTERN_POT},FIXGEOM={self.FIXGEOM}\n\
-LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},SYMMETRY={self.symmetry}\n
+LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},BRUECKNER={self.BRUECKNER},SYMMETRY={self.symmetry}\n
 HFSTABILITY={self.stabilityanalysis},VIB=ANALYTIC)\n\n""")
                 for el in qm_elems:
                     if len(self.specialbasis) > 0:
@@ -391,7 +394,7 @@ REF={self.reference},CHARGE={charge},MULT={mult},{self.frozencore_string}\n\
 MEM_UNIT={self.memory_unit},MEMORY={self.memory},SCF_MAXCYC={self.scf_maxcyc}\n\
 GUESS={self.guessoption},PROP={self.propoption},CC_PROG={self.cc_prog},ABCDTYPE={self.ABCDTYPE}\n\
 SCF_CONV={self.scf_conv},EXTERN_POT={self.EXTERN_POT},FIXGEOM={self.FIXGEOM}\n\
-LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},SYMMETRY={self.symmetry}\n\
+LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},BRUECKNER={self.BRUECKNER},SYMMETRY={self.symmetry}\n\
 HFSTABILITY={self.stabilityanalysis},DERIV_LEVEL=1)\n\n""")
                 for el in qm_elems:
                     if len(self.specialbasis) > 0:
@@ -424,7 +427,7 @@ REF={self.reference},CHARGE={charge},MULT={mult},{self.frozencore_string}\n\
 MEM_UNIT={self.memory_unit},MEMORY={self.memory},SCF_MAXCYC={self.scf_maxcyc}\n\
 GUESS={self.guessoption},PROP={self.propoption},CC_PROG={self.cc_prog},ABCDTYPE={self.ABCDTYPE}\n\
 SCF_CONV={self.scf_conv},EXTERN_POT={self.EXTERN_POT},FIXGEOM={self.FIXGEOM}\n\
-LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},SYMMETRY={self.symmetry}\n\
+LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},BRUECKNER={self.BRUECKNER},SYMMETRY={self.symmetry}\n\
 HFSTABILITY={self.stabilityanalysis},DBOC=ON)\n\n""")
                 #for specbas in self.specialbasis.items():
                 for el in qm_elems:
@@ -455,7 +458,7 @@ REF={self.reference},CHARGE={charge},MULT={mult},{self.frozencore_string}\n\
 MEM_UNIT={self.memory_unit},MEMORY={self.memory},SCF_MAXCYC={self.scf_maxcyc}\n\
 GUESS={self.guessoption},PROP={self.propoption},CC_PROG={self.cc_prog},ABCDTYPE={self.ABCDTYPE}\n\
 SCF_CONV={self.scf_conv},EXTERN_POT={self.EXTERN_POT},FIXGEOM={self.FIXGEOM}\n\
-LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},SYMMETRY={self.symmetry}\n\
+LINEQ_CONV={self.lineq_conv},CC_MAXCYC={self.cc_maxcyc},BRUECKNER={self.BRUECKNER},SYMMETRY={self.symmetry}\n\
 HFSTABILITY={self.stabilityanalysis})\n\n""")
                 #for specbas in self.specialbasis.items():
                 for el in qm_elems:

--- a/interfaces/interface_MRCC.py
+++ b/interfaces/interface_MRCC.py
@@ -208,8 +208,9 @@ def run_mrcc(mrccdir,filename,parallelization,numcores):
 #NOTE: Now setting ccsdthreads and ptthreads to number of cores
 def write_mrcc_input(mrccinput,charge,mult,elems,coords,numcores,Grad=False,keep_orientation=False, PC_coords=None,PC_charges=None,
                      frozen_core_option=None):
+    print("Writing MRCC inputfile")
     with open("MINP", 'w') as inpfile:
-        for m in mrccinput:
+        for m in mrccinput.split('\n'):
             if 'core' in m:
                 print("Warning: ignoring user-defined core option. Using frozen_core_option instead")
             else:

--- a/interfaces/interface_MRCC.py
+++ b/interfaces/interface_MRCC.py
@@ -214,7 +214,7 @@ def write_mrcc_input(mrccinput,charge,mult,elems,coords,numcores,Grad=False,keep
             if 'core' in m:
                 print("Warning: ignoring user-defined core option. Using frozen_core_option instead")
             else:
-                inpfile.write(m)+'\n'
+                inpfile.write(str(m)+'\n')
         #inpfile.write(mrccinput + '\n')
         #Frozen core
         inpfile.write(f'core={frozen_core_option}\n')

--- a/interfaces/interface_MRCC.py
+++ b/interfaces/interface_MRCC.py
@@ -214,7 +214,7 @@ def write_mrcc_input(mrccinput,charge,mult,elems,coords,numcores,Grad=False,keep
             if 'core' in m:
                 print("Warning: ignoring user-defined core option. Using frozen_core_option instead")
             else:
-                inpfile.write(m )
+                inpfile.write(m)+'\n'
         #inpfile.write(mrccinput + '\n')
         #Frozen core
         inpfile.write(f'core={frozen_core_option}\n')

--- a/interfaces/interface_ORCA.py
+++ b/interfaces/interface_ORCA.py
@@ -258,11 +258,10 @@ class ORCATheory:
         print(self.orcablocks)
         print("Charge: {}  Mult: {}".format(charge, mult))
 
-
         #TODO: Make more general
         create_orca_input_plain(self.filename, elems, current_coords, self.orcasimpleinput,self.orcablocks,
                                 charge, mult, extraline=self.extraline, HSmult=self.HSmult, moreadfile=self.moreadfile)
-        print(BC.OKGREEN, "ORCA Calculation started.", BC.END)
+        print(BC.OKGREEN, f"ORCA Calculation started using {numcores} CPU cores", BC.END)
         run_orca_SP_ORCApar(self.orcadir, self.filename + '.inp', numcores=numcores, bind_to_core_option=self.bind_to_core_option, 
                             ignore_ORCA_error=self.ignore_ORCA_error)
         print(BC.OKGREEN, "ORCA Calculation done.", BC.END)

--- a/interfaces/interface_OpenMM.py
+++ b/interfaces/interface_OpenMM.py
@@ -2593,7 +2593,7 @@ def solvate_small_molecule(fragment=None, charge=None, mult=None, watermodel=Non
               write_nonbonded_FF_for_ligand()
               """)
         print("""If you need a full forcefield for the solute then try :
-              small_molecule_parameterizor""")
+              small_molecule_parameterizer""")
         ashexit()
         
     # Read XML-file and check for LJ treatment
@@ -4888,7 +4888,7 @@ def merge_pdb_files(pdbfile_1,pdbfile_2,outputname="merged.pdb"):
     return outputname
 
 
-def small_molecule_parameterizor(xyzfile=None, pdbfile=None, molfile=None, sdffile=None, smiles_string=None,
+def small_molecule_parameterizer(xyzfile=None, pdbfile=None, molfile=None, sdffile=None, smiles_string=None,
                                  forcefield_option='GAFF', gaffversion='gaff-2.11',
                                  output_xmlfile="ligand.xml",
                                 openff_file="openff-2.0.0.offxml",

--- a/interfaces/interface_OpenMM.py
+++ b/interfaces/interface_OpenMM.py
@@ -2200,25 +2200,21 @@ def OpenMM_Modeller(pdbfile=None, forcefield_object=None, forcefield=None, xmlfi
         ashexit()
 
 
-
-
-
-
     if residue_variants == None:
         residue_variants={}
 
 
     # Water model. May be overridden by forcefield below
-    if watermodel == "tip3p":
-        # Possible Problem: this only has water, no ions.
-        waterxmlfile = "tip3p.xml"
-        modeller_solvent_name="tip3p" #Used when adding solvent
-    elif watermodel == "tip3p_charmm":
-        waterxmlfile = "charmm36/water.xml"
-        modeller_solvent_name="tip3p" #Used when adding solvent
-    elif waterxmlfile is not None:
-        # Problem: we need to define watermodel also
-        print("Using waterxmlfile:", waterxmlfile)
+    #if watermodel == "tip3p":
+    #    # Possible Problem: this only has water, no ions.
+    #    waterxmlfile = "tip3p.xml"
+    #    modeller_solvent_name="tip3p" #Used when adding solvent
+    #elif watermodel == "tip3p_charmm":
+    #    waterxmlfile = "charmm36/water.xml"
+    #    modeller_solvent_name="tip3p" #Used when adding solvent
+    #elif waterxmlfile is not None:
+    #    # Problem: we need to define watermodel also
+    #    print("Using waterxmlfile:", waterxmlfile)
     
     # Forcefield options
     if forcefield is not None:
@@ -2235,9 +2231,12 @@ def OpenMM_Modeller(pdbfile=None, forcefield_object=None, forcefield=None, xmlfi
             xmlfile = "amber14-all.xml"
             
             if watermodel is None:
-                print("No watermodel selected. Selecting automatically recommended TIP3P-4B (watermodel='tip3pfb')")
-                print("This is a reparameterized version of TIP3P")
-                watermodel='tip3pfb'
+                print("No watermodel selected.")
+                if waterxmlfile is None:
+                    print("No waterxmlfile selected either")
+                    print("Selecting automatically recommended TIP3P-4B (watermodel='tip3pfb')")
+                    print("This is a reparameterized version of TIP3P")
+                    watermodel='tip3pfb'
             print("watermodel:", watermodel)
             # Using specific Amber FB version of TIP3P
             if watermodel.lower() == "tip3pfb" or watermodel.lower() == "tip3p-fb":
@@ -2252,9 +2251,18 @@ def OpenMM_Modeller(pdbfile=None, forcefield_object=None, forcefield=None, xmlfi
         elif forcefield == 'CHARMM36':
             xmlfile = "charmm36.xml"
             # Using specific CHARMM36 version of TIP3P
-            watermodel="tip3p"
-            modeller_solvent_name="tip3p" #Used when adding solvent
-            waterxmlfile = "charmm36/water.xml"
+            if watermodel is None:
+                print("No watermodel selected.")
+                if waterxmlfile is None:
+                    print("No waterxmlfile selected either")
+                    print("Selecting automatically recommended CHARMM-style TIP3P")
+                    watermodel='tip3p'
+
+            print("watermodel:", watermodel)
+            if watermodel.lower() == "tip3p":
+                modeller_solvent_name="tip3p" #Used when adding solvent
+                waterxmlfile = "charmm36/water.xml"
+            print("Waterxmlfile selected:", waterxmlfile)
         elif forcefield == 'CHARMM2013':
             xmlfile = "charmm_polar_2013.xml"
         elif forcefield == 'Amoeba2013':

--- a/interfaces/interface_OpenMM.py
+++ b/interfaces/interface_OpenMM.py
@@ -2430,7 +2430,7 @@ def OpenMM_Modeller(pdbfile=None, forcefield_object=None, forcefield=None, xmlfi
     else:
         print("We are doing explicit solvation")
         print("Setting periodic to True")
-        periodic=False
+        periodic=True
         print("Adding solvent, modeller_solvent_name:", modeller_solvent_name)
         if solvent_boxdims is not None:
             print("Solvent boxdimension provided: {} Å".format(solvent_boxdims))

--- a/interfaces/interface_OpenMM.py
+++ b/interfaces/interface_OpenMM.py
@@ -3718,20 +3718,22 @@ class OpenMM_MDclass:
         #PERIODIC BOX VECTORS
         ##########################
         self.state = self.simulation.context.getState(getEnergy=True, getPositions=True, getForces=True, enforcePeriodicBox=self.enforcePeriodicBox)
-        print("Checking PBC vectors:")
-        a, b, c = self.state.getPeriodicBoxVectors()
-        print(f"A: ", a)
-        print(f"B: ", b)
-        print(f"C: ", c)
-        print("a 0", a[0])
-        # Set new PBC vectors since they may have changed
-        print("Updating PBC vectors in simulation.context, OpenMM system and OpenMM topology")
-        # Context. Used?
-        self.simulation.context.setPeriodicBoxVectors(a, b, c)
-        # System. Necessary
-        self.openmmobject.system.setDefaultPeriodicBoxVectors(a, b, c)
-        #Topology (for header in PDB-files). Necessary
-        self.openmmobject.topology.setPeriodicBoxVectors(self.state.getPeriodicBoxVectors())
+        
+        if self.openmmobject.Periodic is True:
+            print("Checking PBC vectors:")
+            a, b, c = self.state.getPeriodicBoxVectors()
+            print(f"A: ", a)
+            print(f"B: ", b)
+            print(f"C: ", c)
+            print("a 0", a[0])
+            # Set new PBC vectors since they may have changed
+            print("Updating PBC vectors in simulation.context, OpenMM system and OpenMM topology")
+            # Context. Used?
+            self.simulation.context.setPeriodicBoxVectors(a, b, c)
+            # System. Necessary
+            self.openmmobject.system.setDefaultPeriodicBoxVectors(a, b, c)
+            #Topology (for header in PDB-files). Necessary
+            self.openmmobject.topology.setPeriodicBoxVectors(self.state.getPeriodicBoxVectors())
 
         ########################################
         # Writing final frame to disk as PDB. 
@@ -4249,7 +4251,9 @@ def Gentle_warm_up_MD(theory=None, fragment=None, time_steps=[0.0005,0.001,0.004
         print("check_gradient_first is True")
         print("Will run singlepoint gradient calculation to check for large forces")
         theory.force_run=True
-        SP_result = Singlepoint(theory=theory, fragment=fragment, Grad=True)
+        theory.printlevel=0
+        SP_result = Singlepoint(theory=theory, fragment=fragment, Grad=True, printlevel=0)
+        theory.printlevel=2
         badindices = check_gradient_for_bad_atoms(fragment=fragment,gradient=SP_result.gradient, threshold=gradient_threshold)
         if len(badindices) > 0:
             print(f"\nNumber of atoms with large forces: {len(badindices)}")

--- a/interfaces/interface_ccpy.py
+++ b/interfaces/interface_ccpy.py
@@ -18,7 +18,8 @@ import ash.settings_ash
 
 class ccpyTheory:
     def __init__(self, pyscftheoryobject=None, filename='input.dat', printlevel=2,
-                moreadfile=None, initial_orbitals='MP2', memory=20000, frozencore=True, tol=1e-10, numcores=1, 
+                moreadfile=None, initial_orbitals='MP2', memory=20000, frozencore=True, tol=1e-10, numcores=1,
+                cc_maxiter=300,
                 method="CCPQ", adaptive=False, percentages=None):
 
         self.theorynamelabel="ccpy"
@@ -55,6 +56,7 @@ class ccpyTheory:
         self.frozencore=frozencore
         self.memory=memory #Memory in MB (total) assigned to PySCF mcscf object
         self.initial_orbitals=initial_orbitals #Initial orbitals to be used (unless moreadfile option)
+        self.cc_maxiter=cc_maxiter #Maximum number of iterations for CC calculation
 
         #CCpy adaptive
         if adaptive is True and self.percentages is None:
@@ -147,7 +149,10 @@ class ccpyTheory:
         print("self.pyscftheoryobject.mf:", self.pyscftheoryobject.mf)
         driver = Driver.from_pyscf(self.pyscftheoryobject.mf, nfrozen=self.frozen_core_orbs)
         print("driver:",driver)
+        #Some settings
+        driver.options["maximum_iterations"] = self.cc_maxiter
         driver.system.print_info()
+
 
         if self.adaptive is True:
             print("adaptive CC(P;Q) calculation.")

--- a/interfaces/interface_dice.py
+++ b/interfaces/interface_dice.py
@@ -83,14 +83,17 @@ class DiceTheory:
 
         #Path to Dice binary
         self.dice_binary=self.dicedir+"/bin/Dice"
-        #Put Dice script dir in path
+        #Put Dice script dir in path (QMCUtils)
         sys.path.insert(0, self.dicedir+"/scripts")
 
         #Now import pyscf, shciscf (plugin), qmcutils (Dice dir scripts)
         if SHCI == True and Dice_SHCI_direct != True:
             self.load_pyscf()
             self.load_shciscf()
-        self.load_qmcutils()
+        #Only load QMCUtils if AFQMC is True or NEVPT2 is True
+        if NEVPT2 is True or AFQMC is True:
+            print("NEVPT2 or AFQMC is True. This requires QMCUtils module to be installed.")
+            self.load_qmcutils()
 
         if numcores > 1:
             try:
@@ -222,14 +225,15 @@ MPIPREFIX=""
             print(m)
             ashexit()
     def load_qmcutils(self):
+        print("Attempting to load QMCUtils module")
         try:
             import QMCUtils
             self.QMCUtils=QMCUtils
         except ModuleNotFoundError as me:
             print("ModuleNotFoundError:")
             print("Exception message:", me)
-            print("Either: QMCUtils requires another module (pandas?). Please install it via conda or pip.")
-            print("or: Problem importing QMCUtils. Dice directory is probably incorrectly set")
+            print("Problem importing QMCUtils. Dice directory may be incorrectly set")
+            print("Or: QMCUtils requires another module (pandas?). Please install it via conda or pip.")
             ashexit()
     #Set numcores method
     def set_numcores(self,numcores):

--- a/interfaces/interface_dice.py
+++ b/interfaces/interface_dice.py
@@ -794,7 +794,7 @@ noio
                                                                         mo_coefficients, occupations, label="SHCI_Final_nat_orbs")
                     #Dipole moment
                     print("Now doing dipole")
-                    rdm1 = self.mch.make_rdm1()
+                    rdm1 = self.mch.make_rdm1(ao_repr=True)
                     #rdm1 = self.mch.fcisolver.make_rdm1(self.mch.ci, self.mch.nmo, self.mch.nelec)
                     dipole = self.pyscftheoryobject.get_dipole_moment(dm=rdm1)
 

--- a/interfaces/interface_dice.py
+++ b/interfaces/interface_dice.py
@@ -794,7 +794,7 @@ noio
                                                                         mo_coefficients, occupations, label="SHCI_Final_nat_orbs")
                     #Dipole moment
                     print("Now doing dipole")
-                    rdm1 = self.mch.make_rdm1(ao_repr=True)
+                    rdm1 = self.mch.make_rdm1()
                     #rdm1 = self.mch.fcisolver.make_rdm1(self.mch.ci, self.mch.nmo, self.mch.nelec)
                     dipole = self.pyscftheoryobject.get_dipole_moment(dm=rdm1)
 

--- a/interfaces/interface_dice.py
+++ b/interfaces/interface_dice.py
@@ -790,7 +790,13 @@ noio
                     occupations, mo_coefficients = pyscf.mcscf.addons.make_natural_orbitals(self.mch)
                     print("SHCI natural orbital occupations:", occupations)
                     print("\nWriting natural orbitals to Moldenfile")
-                    self.pyscftheoryobject.write_orbitals_to_Moldenfile(self.pyscftheoryobject.mol, mo_coefficients, occupations, label="SHCI_Final_nat_orbs")
+                    self.pyscftheoryobject.write_orbitals_to_Moldenfile(self.pyscftheoryobject.mol, 
+                                                                        mo_coefficients, occupations, label="SHCI_Final_nat_orbs")
+                    #Dipole moment
+                    print("Now doing dipole")
+                    rdm1 = self.mch.make_rdm1(ao_repr=True)
+                    #rdm1 = self.mch.fcisolver.make_rdm1(self.mch.ci, self.mch.nmo, self.mch.nelec)
+                    dipole = self.pyscftheoryobject.get_dipole_moment(dm=rdm1)
 
         print("Dice is finished")
         #Cleanup Dice scratch stuff (big files)

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -792,7 +792,7 @@ class PySCFTheory:
         if self.MP2_DF is False:
             print("Now calculating unrelaxed canonical MP2 density")
             #This is unrelaxed canonical MP2 density
-            mp2_dm = mp2object.make_rdm1(ao_repr=False)
+            mp2_dm = mp2object.make_rdm1(ao_repr=True)
             density_type='MP2'
         else:
             #RDMs: Unrelaxed vs. Relaxed

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -857,6 +857,9 @@ class PySCFTheory:
                 natocc,natorb,rdm1 = self.calculate_CCSD_T_natorbs(cc,mf)
                 print("Mulliken analysis for CCSD(T) density matrix")
                 self.run_population_analysis(mf, unrestricted=unrestricted, dm=rdm1, type='Mulliken', label='CCSD(T)')
+
+                dipole = self.get_dipole_moment(dm=rdm1)
+                print(f"Dipole moment: {dipole} A.U.")
             elif CCmethod == 'BCCD(T)':
                 print("Density for BCCD(T) has not been tested")
                 ashexit()
@@ -881,12 +884,12 @@ class PySCFTheory:
             print("pyscf postSCF dipole moment requeste")
             if dm is None:
                 print("A pyscf density matrix (dm= ) is required as input")
-            dipole_debye = self.mf.dip_moment(dm=dm_re,unit='A.U.')
+                dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
         else:
             #MF dipole moment
-            dipole_debye = self.mf.dip_moment(unit='A.U.')
+            dipole = self.mf.dip_moment(unit='A.U.')
 
-        return dipole_debye
+        return dipole
     def get_polarizability_tensor(self):
         try:
             from pyscf.prop import polarizability
@@ -1619,6 +1622,8 @@ class PySCFTheory:
                 mo_coefficients=None
 
                 #Optional Frozen natural orbital approach via MP2 natural orbitals
+                #NOTE: this is not entirely correct since occupied orbitals are natural orbitals rather than frozen HF orbitals as in the original method
+                #Not sure how much it matters
                 if self.FNO is True:
                     print("FNO is True")
                     if self.FNO_orbitals =='MP2':

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -435,11 +435,11 @@ class PySCFTheory:
                 #Now run DMP2 object
                 mp2.run()
 
-                #Make natorbs
-                #NOTE: This should not have to recalculate RDM here since provided
-                #natocc, natorb = dmp2.make_natorbs(rdm1_mo=dfmp2_dm, relaxed=relaxed)
-                #NOTE: Slightly silly, calling make_natural_orbitals will cause dm calculation again
-                natocc, natorb = pyscf.mcscf.addons.make_natural_orbitals(mp2)                
+            #Make natorbs
+            #NOTE: This should not have to recalculate RDM here since provided
+            #natocc, natorb = dmp2.make_natorbs(rdm1_mo=dfmp2_dm, relaxed=relaxed)
+            #NOTE: Slightly silly, calling make_natural_orbitals will cause dm calculation again
+            natocc, natorb = pyscf.mcscf.addons.make_natural_orbitals(mp2)                
             #natocc, natorb = self.mcscf.addons.make_natural_orbitals(mp2)
         elif method =='FCI':
             print("Running FCI natural orbital calculation")

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -879,23 +879,14 @@ class PySCFTheory:
         return energy
     #Method to grab dipole moment from pyscftheory object  (assumes run has been executed)
     def get_dipole_moment(self, dm=None):
-        if self.postSCF is True:
-            print("pyscf postSCF dipole moment requested")
-            if dm is None:
-                print("For postSCF calculations, a density matrix (dm= ) is required as input")
-                ashexit()
-            dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
+        print("get_dipole_moment")
+        if dm is None:
+            print("No DM provided. Using mean-field object dm")
+            #MF dipole moment
+            dipole = self.mf.dip_moment(unit='A.U.')
         else:
-            print("pySCF post-SCF False case")
-            if dm is None:
-                print("No DM provided. Using mean-field object dm")
-                #MF dipole moment
-                dipole = self.mf.dip_moment(unit='A.U.')
-            else:
-                print("Using provided DM")
-                dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
-
-
+            print("Using provided DM")
+            dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
         return dipole
     def get_polarizability_tensor(self):
         try:

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -896,6 +896,15 @@ class PySCFTheory:
         energy = ccsd_result.e_tot
         print("CCSD energy:", energy)
 
+        #T1 diagnostic
+        if unrestricted is True:
+            T1_diagnostic_alpha = pyscf.cc.ccsd.get_t1_diagnostic(cc.t1[0])
+            T1_diagnostic_beta = pyscf.cc.ccsd.get_t1_diagnostic(cc.t1[1])
+            print("T1 diagnostic (alpha):", T1_diagnostic_alpha)
+            print("T1 diagnostic (beta):", T1_diagnostic_beta)
+        else:
+            T1_diagnostic = pyscf.cc.ccsd.get_t1_diagnostic(cc.t1)
+            print("T1 diagnostic:", T1_diagnostic)
         #Brueckner coupled-cluster wrapper, using an outer-loop algorithm.
         if 'BCCD' in CCmethod:
             print("Bruckner CC active. Now doing BCCD on top of CCSD calculation.")

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -1368,6 +1368,8 @@ class PySCFTheory:
                 s2, spinmult = self.mf.spin_square()
                 print("UHF/UKS <S**2>:", s2)
                 print(f"UHF/UKS spinmult: {spinmult}\n")
+            print("SCF Dipole moment")
+            self.get_dipole_moment()
             #Dispersion correction
             if self.dispersion != None:
                 if self.dispersion == "D3" or self.dispersion == "D4":

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -882,12 +882,19 @@ class PySCFTheory:
         if self.postSCF is True:
             print("pyscf postSCF dipole moment requested")
             if dm is None:
-                print("A pyscf density matrix (dm= ) is required as input")
+                print("For postSCF calculations, a density matrix (dm= ) is required as input")
                 ashexit()
             dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
         else:
-            #MF dipole moment
-            dipole = self.mf.dip_moment(unit='A.U.')
+            print("pySCF post-SCF False case")
+            if dm is None:
+                print("No DM provided. Using mean-field object dm")
+                #MF dipole moment
+                dipole = self.mf.dip_moment(unit='A.U.')
+            else:
+                print("Using provided DM")
+                dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
+
 
         return dipole
     def get_polarizability_tensor(self):
@@ -1368,7 +1375,7 @@ class PySCFTheory:
                 s2, spinmult = self.mf.spin_square()
                 print("UHF/UKS <S**2>:", s2)
                 print(f"UHF/UKS spinmult: {spinmult}\n")
-            print("SCF Dipole moment")
+            print("SCF Dipole moment:")
             self.get_dipole_moment()
             #Dispersion correction
             if self.dispersion != None:

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -30,7 +30,7 @@ class PySCFTheory:
                   CC=False, CCmethod=None, CC_direct=False, frozen_core_setting='Auto', cc_maxcycle=200, cc_diis_space=6,
                   CC_density=False,
                   CAS=False, CASSCF=False, CASSCF_numstates=1, CASSCF_weights=None, CASSCF_mults=None, CASSCF_wfnsyms=None, active_space=None, stability_analysis=False, casscf_maxcycle=200,
-                  frozen_virtuals=None, FNO=False, FNO_thresh=None, x2c=False,
+                  frozen_virtuals=None, FNO=False, FNO_orbitals='MP2', FNO_thresh=None, x2c=False,
                   moreadfile=None, write_chkfile_name='pyscf.chk', noautostart=False,
                   AVAS=False, DMET_CAS=False, CAS_AO_labels=None, APC=False, apc_max_size=(2,2),
                   cas_nmin=None, cas_nmax=None, losc=False, loscfunctional=None, LOSC_method='postSCF',
@@ -103,6 +103,7 @@ class PySCFTheory:
         self.cc_diis_space=cc_diis_space
         self.FNO=FNO
         self.FNO_thresh=FNO_thresh
+        self.FNO_orbitals=FNO_orbitals
         self.frozen_core_setting=frozen_core_setting
         self.frozen_virtuals=frozen_virtuals
         self.gridlevel=gridlevel
@@ -274,6 +275,7 @@ class PySCFTheory:
         print("CC DIIS space size:", self.cc_diis_space)
         print("FNO-CC:", self.FNO)
         print("FNO_thresh:", self.FNO_thresh)
+        print("FNO orbitals:", self.FNO_orbitals)
 
         print("Frozen_core_setting:", self.frozen_core_setting)
         print("Frozen_virtual orbitals:",self.frozen_virtuals)
@@ -1619,10 +1621,15 @@ class PySCFTheory:
                 #Optional Frozen natural orbital approach via MP2 natural orbitals
                 if self.FNO is True:
                     print("FNO is True")
-                    print("MP2 natural orbitals on!")
-                    print("Will calculate MP2 natural orbitals to use as input in CC job")
-                    natocc, mo_coefficients = self.calculate_natural_orbitals(self.mol,self.mf, method='MP2', elems=elems)
-
+                    if self.FNO_orbitals =='MP2':
+                        print("MP2 natural orbitals on!")
+                        print("Will calculate MP2 natural orbitals to use as input in CC job")
+                        natocc, mo_coefficients = self.calculate_natural_orbitals(self.mol,self.mf, method='MP2', elems=elems)
+                    elif self.FNO_orbitals =='CCSD':
+                        print("CCSD natural orbitals on!")
+                        print("Will calculate CCSD natural orbitals to use as input in CC job")
+                        natocc, mo_coefficients = self.calculate_natural_orbitals(self.mol,self.mf, method='CCSD', elems=elems)
+                    
                     #Optional natorb truncation if FNO_thresh is chosen
                     if self.FNO_thresh is not None:
                         print("FNO thresh option chosen:", self.FNO_thresh)

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -896,15 +896,28 @@ class PySCFTheory:
         energy = ccsd_result.e_tot
         print("CCSD energy:", energy)
 
-        #T1 diagnostic
+        #T1,D1 and D2 diagnostics
         if unrestricted is True:
             T1_diagnostic_alpha = pyscf.cc.ccsd.get_t1_diagnostic(cc.t1[0])
             T1_diagnostic_beta = pyscf.cc.ccsd.get_t1_diagnostic(cc.t1[1])
             print("T1 diagnostic (alpha):", T1_diagnostic_alpha)
             print("T1 diagnostic (beta):", T1_diagnostic_beta)
+            D1_diagnostic_alpha = pyscf.cc.ccsd.get_d1_diagnostic(cc.t1[0])
+            D1_diagnostic_beta = pyscf.cc.ccsd.get_d1_diagnostic(cc.t1[1])
+            print("D1 diagnostic (alpha):", D1_diagnostic_alpha)
+            print("D1 diagnostic (beta):", D1_diagnostic_beta)
+            D2_diagnostic_alpha = pyscf.cc.ccsd.get_d2_diagnostic(cc.t2[0])
+            D2_diagnostic_beta = pyscf.cc.ccsd.get_d2_diagnostic(cc.t2[1])
+            print("D2 diagnostic (alpha):", D2_diagnostic_alpha)
+            print("D2 diagnostic (beta):", D2_diagnostic_beta)
         else:
             T1_diagnostic = pyscf.cc.ccsd.get_t1_diagnostic(cc.t1)
             print("T1 diagnostic:", T1_diagnostic)
+            D1_diagnostic = pyscf.cc.ccsd.get_d1_diagnostic(cc.t1)
+            print("D1 diagnostic:", D1_diagnostic)
+            D2_diagnostic = pyscf.cc.ccsd.get_d2_diagnostic(cc.t2)
+            print("D2 diagnostic:", D2_diagnostic)
+        
         #Brueckner coupled-cluster wrapper, using an outer-loop algorithm.
         if 'BCCD' in CCmethod:
             print("Bruckner CC active. Now doing BCCD on top of CCSD calculation.")

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -851,8 +851,11 @@ class PySCFTheory:
             print(f"Now calculating {CCmethod} density matrix and natural orbitals")
             if CCmethod == 'CCSD':
                 natocc, natorb = pyscf.mcscf.addons.make_natural_orbitals(cc)
+                self.get_dipole_moment(dm=cc.make_rdm1())
             elif CCmethod == 'BCCD':
                 natocc, natorb = pyscf.mcscf.addons.make_natural_orbitals(mybcc)
+                #Dipole moment
+                self.get_dipole_moment(dm=mybcc.make_rdm1())
             elif CCmethod == 'CCSD(T)':
                 natocc,natorb,rdm1 = self.calculate_CCSD_T_natorbs(cc,mf)
                 print("Mulliken analysis for CCSD(T) density matrix")

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -27,7 +27,7 @@ class PySCFTheory:
                   mom=False, mom_occindex=0, mom_virtindex=1, mom_spinmanifold=0,
                   dispersion=None, densityfit=False, auxbasis=None, sgx=False, magmom=None,
                   pe=False, potfile='', filename='pyscf', memory=3100, conv_tol=1e-8, verbose_setting=4, 
-                  CC=False, CCmethod=None, CC_direct=False, frozen_core_setting='Auto', cc_maxcycle=200,
+                  CC=False, CCmethod=None, CC_direct=False, frozen_core_setting='Auto', cc_maxcycle=200, cc_diis_space=6,
                   CC_density=False,
                   CAS=False, CASSCF=False, CASSCF_numstates=1, CASSCF_weights=None, CASSCF_mults=None, CASSCF_wfnsyms=None, active_space=None, stability_analysis=False, casscf_maxcycle=200,
                   frozen_virtuals=None, FNO=False, FNO_thresh=None, x2c=False,
@@ -100,6 +100,7 @@ class PySCFTheory:
         self.CC_density=CC_density #CC density True or False
         self.CC_direct=CC_direct
         self.cc_maxcycle=cc_maxcycle
+        self.cc_diis_space=cc_diis_space
         self.FNO=FNO
         self.FNO_thresh=FNO_thresh
         self.frozen_core_setting=frozen_core_setting
@@ -270,6 +271,7 @@ class PySCFTheory:
         print("CC direct:", self.CC_direct)
         print("CC density:", self.CC_density)
         print("CC maxcycles:", self.cc_maxcycle)
+        print("CC DIIS space size:", self.cc_diis_space)
         print("FNO-CC:", self.FNO)
         print("FNO_thresh:", self.FNO_thresh)
 
@@ -806,6 +808,7 @@ class PySCFTheory:
         #Setting CCSD maxcycles (default 200)
         cc.max_cycle=self.cc_maxcycle
         cc.verbose=5 #Shows CC iterations with 5
+        cc.diis_space=self.cc_diis_space  #DIIS space size (default 6)
 
         #Switch to integral-direct CC if user-requested
         #NOTE: Faster but only possible for small/medium systems

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -851,11 +851,11 @@ class PySCFTheory:
             print(f"Now calculating {CCmethod} density matrix and natural orbitals")
             if CCmethod == 'CCSD':
                 natocc, natorb = pyscf.mcscf.addons.make_natural_orbitals(cc)
-                self.get_dipole_moment(dm=cc.make_rdm1())
+                self.get_dipole_moment(dm=cc.make_rdm1(ao_repr=True))
             elif CCmethod == 'BCCD':
                 natocc, natorb = pyscf.mcscf.addons.make_natural_orbitals(mybcc)
                 #Dipole moment
-                self.get_dipole_moment(dm=mybcc.make_rdm1())
+                self.get_dipole_moment(dm=mybcc.make_rdm1(ao_repr=True))
             elif CCmethod == 'CCSD(T)':
                 natocc,natorb,rdm1 = self.calculate_CCSD_T_natorbs(cc,mf)
                 print("Mulliken analysis for CCSD(T) density matrix")

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -835,7 +835,8 @@ class PySCFTheory:
                 natocc,natorb,rdm1 = self.calculate_CCSD_T_natorbs(cc,mf)
                 print("Mulliken analysis for CCSD(T) density matrix")
                 self.run_population_analysis(mf, unrestricted=unrestricted, dm=rdm1, type='Mulliken', label='CCSD(T)')
-            #Printing occupaations
+
+            #Printing occupations
             print(f"\n{CCmethod} natural orbital occupations:")
             print(natocc)
             print()

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -824,10 +824,11 @@ class PySCFTheory:
 
         #Brueckner coupled-cluster wrapper, using an outer-loop algorithm.
         if 'BCCD' in CCmethod:
-            print("Bruckner CC active. Doing.")
+            print("Bruckner CC active. Now doing BCCD on top of CCSD calculation.")
             from pyscf.cc.bccd import bccd_kernel_
             mybcc = bccd_kernel_(cc, diis=True, verbose=4,canonicalization=True)
             bccd_energy = mybcc.e_tot
+            print("BCCD energy:", bccd_energy)
         
         #(T) part
         if CCmethod == 'CCSD(T)':
@@ -860,11 +861,13 @@ class PySCFTheory:
                 natocc,natorb,rdm1 = self.calculate_CCSD_T_natorbs(cc,mf)
                 print("Mulliken analysis for CCSD(T) density matrix")
                 self.run_population_analysis(mf, unrestricted=unrestricted, dm=rdm1, type='Mulliken', label='CCSD(T)')
-
                 dipole = self.get_dipole_moment(dm=rdm1)
             elif CCmethod == 'BCCD(T)':
-                print("Density for BCCD(T) has not been tested")
-                ashexit()
+                print("Warning: Density for BCCD(T) has not been tested")
+                natocc,natorb,rdm1 = self.calculate_CCSD_T_natorbs(mybcc,mf)
+                print("Mulliken analysis for BCCD(T) density matrix")
+                self.run_population_analysis(mf, unrestricted=unrestricted, dm=rdm1, type='Mulliken', label='BCCD(T)')
+                dipole = self.get_dipole_moment(dm=rdm1)
 
             #Printing occupations
             print(f"\n{CCmethod} natural orbital occupations:")

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -884,7 +884,8 @@ class PySCFTheory:
             print("pyscf postSCF dipole moment requeste")
             if dm is None:
                 print("A pyscf density matrix (dm= ) is required as input")
-                dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
+                ashexit()
+            dipole = self.mf.dip_moment(dm=dm,unit='A.U.')
         else:
             #MF dipole moment
             dipole = self.mf.dip_moment(unit='A.U.')

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -19,7 +19,7 @@ import copy
 
 class PySCFTheory:
     def __init__(self, printsetting=False, printlevel=2, numcores=1, label=None,
-                  scf_type=None, basis=None, ecp=None, functional=None, gridlevel=5, symmetry=False, guess='minao',
+                  scf_type=None, basis=None, basis_file=None, ecp=None, functional=None, gridlevel=5, symmetry=False, guess='minao',
                   soscf=False, damping=None, diis_method='DIIS', diis_start_cycle=0, level_shift=None,
                   fractional_occupation=False, scf_maxiter=50, direct_scf=True, GHF_complex=False, collinear_option='mcol',
                   BS=False, HSmult=None,spinflipatom=None, atomstoflip=None,
@@ -47,8 +47,9 @@ class PySCFTheory:
         if scf_type is None:
             print("Error: You must select an scf_type, e.g. 'RHF', 'UHF', 'GHF', 'RKS', 'UKS', 'GKS'")
             ashexit()
-        if basis is None:
-            print("Error: You must give a basis set. Basis set can a name (string) or dict (elements as keys)")
+        if basis is None and basis_file is None:
+            print("Error: You must provide basis or basis_file kewyrod . Basis set can a name (string) or dict (elements as keys)")
+            print("basis_file should be a string of the filename containing basis set in NWChem format")
             ashexit()
         if functional is not None:
             print(f"Functional keyword: {functional} chosen. DFT is on!")
@@ -96,6 +97,7 @@ class PySCFTheory:
         self.conv_tol=conv_tol
         self.direct_scf=direct_scf
         self.basis=basis #Basis set can be string or dict with elements as keys
+        self.basis_file = basis_file
         self.magmom=magmom
         self.ecp=ecp
         self.functional=functional
@@ -273,6 +275,7 @@ class PySCFTheory:
         print("Grid level:", self.gridlevel)
         print("verbose_setting:", self.verbose_setting)
         print("Basis:", self.basis)
+        print("Basis-file:", self.basis_file)
         print("SCF stability analysis:", self.stability_analysis)
         print("Functional:", self.functional)
         print("Coupled cluster:", self.CC)
@@ -1101,10 +1104,26 @@ class PySCFTheory:
         self.mol.symmetry = self.symmetry
         self.mol.charge = charge
         self.mol.spin = mult-1
-        print("Setting mol.spin to:", mult-1)
+        ########
+        # BASIS
+        ########
         #PYSCF basis object: https://sunqm.github.io/pyscf/tutorial.html
         #Object can be string ('def2-SVP') or a dict with element-specific keys and values
-        self.mol.basis=self.basis
+        #NOTE: Basis-file parsing not quite ready.
+        #NOTE: Need to read file containing also basis for that element I think
+        #NOTE: We should also support basis set exchange API: https://github.com/pyscf/pyscf/issues/1299
+        if self.basis_file != None:
+            print("basis_file option is not ready")
+            ashexit()
+            #with open(self.basis_file) as b:
+            #    basis_string_from_file=' '.join(b.readlines())
+            #print("basis_string_from_file:", basis_string_from_file)
+            self.mol.basis= pyscf.gto.basis.parse(basis_string_from_file)
+            #https://github.com/nmardirossian/PySCF_Tutorial/blob/master/dev_guide.ipynb
+            #self.mol.basis = #{'H': gto.basis.read('basis/STO-2G.dat')
+        else:
+            self.mol.basis=self.basis
+        print(self.mol.basis)
         #Optional setting magnetic moments 
         if self.magmom != None:
             print("Setting magnetic moments from user-input:", self.magmom)

--- a/interfaces/interface_pyscf.py
+++ b/interfaces/interface_pyscf.py
@@ -859,7 +859,6 @@ class PySCFTheory:
                 self.run_population_analysis(mf, unrestricted=unrestricted, dm=rdm1, type='Mulliken', label='CCSD(T)')
 
                 dipole = self.get_dipole_moment(dm=rdm1)
-                print(f"Dipole moment: {dipole} A.U.")
             elif CCmethod == 'BCCD(T)':
                 print("Density for BCCD(T) has not been tested")
                 ashexit()
@@ -881,7 +880,7 @@ class PySCFTheory:
     #Method to grab dipole moment from pyscftheory object  (assumes run has been executed)
     def get_dipole_moment(self, dm=None):
         if self.postSCF is True:
-            print("pyscf postSCF dipole moment requeste")
+            print("pyscf postSCF dipole moment requested")
             if dm is None:
                 print("A pyscf density matrix (dm= ) is required as input")
                 ashexit()

--- a/modules/module_QMMM.py
+++ b/modules/module_QMMM.py
@@ -1278,6 +1278,39 @@ def grab_resids_from_pdbfile(pdbfile):
 
     return resids
 
+#Grab resid column from PSF-file and return list of resids
+# NOTE: New resid-indices are used to avoid problem of PSF-file having 
+# repeating sequences of resids, additional chains or segments
+def grab_resids_from_psffile(psffile):
+    resids=[] #New list of resid indices, starting from 0
+    actual_resids=[] #Actual resid values from PSF-file, used to check if resid has changed
+    indexcount=0 #This will be used to define residues
+    #resnames=[]
+    with open(psffile) as f:
+        for line in f:
+            if 'REMARKS' in line:
+                continue
+            if len(line.split()) > 8:
+                print(line)
+                resname_part=line.split()[3]
+                resid_part=int(line.split()[2])
+                #resnames.append(resname_part)
+                #Very first atom and first residue
+                if len(resids) == 0:
+                    resids.append(indexcount)
+                    actual_resids.append(resid_part)
+                #Checking if resid in PDB-file is the same 
+                elif resid_part == actual_resids[-1]:
+                    resids.append(indexcount)
+                    actual_resids.append(resid_part)
+                # Resid changed, meaning new residue
+                else:
+                    indexcount+=1
+                    #New residue
+                    resids.append(indexcount)
+                    actual_resids.append(resid_part)
+    return resids
+
 #Read atomic charges present in PSF-file. assuming Xplor format
 def read_charges_from_psf(file):
     charges=[]
@@ -1297,20 +1330,13 @@ def read_charges_from_psf(file):
     return charges
 
 #Define active region based on radius from an origin atom.
-#Requires fragment (for coordinates) and resids list inside OpenMMTheory object
-#TODO: Also allow PDBfile to grab resid information from?? Prettier since we don't have to create an OpenMMTheory object
-def actregiondefine(pdbfile=None, mmtheory=None, fragment=None, radius=None, originatom=None):
-    """ActRegionDefine function
+#Requires fragment (for coordinates) and residue information from either:
+# 1. resids list inside OpenMMTheory object
+# 2. residues taken from PDB-file
+# 3. residues taken from PSF-file
 
-    Args:
-        mmtheory ([OpenMMTheory]): OpenMMTheory object. Defaults to None.
-        fragment ([Fragment]): ASH Fragment. Defaults to None.
-        radius ([int]): Radius (in Angstrom). Defaults to None.
-        originatom ([int]): Origin atom for radius. Defaults to None.
+def actregiondefine(pdbfile=None, mmtheory=None, psffile=None, fragment=None, radius=None, originatom=None):
 
-    Returns:
-        [type]: [description]
-    """
     print_line_with_mainheader("ActregionDefine")
 
     #Checking if proper information has been provided
@@ -1320,9 +1346,10 @@ def actregiondefine(pdbfile=None, mmtheory=None, fragment=None, radius=None, ori
     if pdbfile == None and fragment == None:
         print("actregiondefine requires either fragment or pdbfile arguments (for coordinates)")
         ashexit()
-    if pdbfile == None and mmtheory == None:
-        print("actregiondefine requires either pdbfile or mmtheory arguments (for residue topology information)")
+    if pdbfile == None and mmtheory == None and psffile == None:
+        print("actregiondefine requires either pdbfile, psffile or mmtheory arguments (for residue topology information)")
         ashexit()
+    
     #Creating fragment from pdbfile 
     if fragment == None:
         print("No ASH fragment provided. Creating ASH fragment from PDBfile")
@@ -1341,7 +1368,11 @@ def actregiondefine(pdbfile=None, mmtheory=None, fragment=None, radius=None, ori
             ashexit()
         #Defining list of residue from OpenMMTheory object 
         resids=mmtheory.resids
+    elif psffile != None:
+        print("PSF-file provided. Using residue information")
+        resids = grab_resids_from_psffile(psffile)
     else:
+        print("PDB-file provided. Using residue information")
         #No mmtheory but PDB file should have been provided
         #Defining resids list from PDB-file
         #NOTE: Call grab_resids_from_pdbfile

--- a/modules/module_QMMM.py
+++ b/modules/module_QMMM.py
@@ -1291,7 +1291,6 @@ def grab_resids_from_psffile(psffile):
             if 'REMARKS' in line:
                 continue
             if len(line.split()) > 8:
-                print(line)
                 resname_part=line.split()[3]
                 resid_part=int(line.split()[2])
                 #resnames.append(resname_part)

--- a/modules/module_singlepoint.py
+++ b/modules/module_singlepoint.py
@@ -8,6 +8,7 @@
 import numpy as np
 import time
 import subprocess as sp
+import shutil
 
 import ash
 from ash.functions.functions_general import ashexit, BC,print_time_rel,print_line_with_mainheader
@@ -101,7 +102,14 @@ def Singlepoint_theories(theories=None, fragment=None, charge=None, mult=None):
 
         #Running single-point. 
         result = Singlepoint(theory=theory, fragment=fragment, charge=charge, mult=mult)
-        
+
+        #Preserve outputfile
+        calc_label = "Frag_" + theory.__class__.__name__+"_"
+        try:
+            shutil.copyfile(theory.filename+'.out', f'./{calc_label}.out')
+        except:
+            pass
+
         print("Theory Label: {} Energy: {} Eh".format(theory.label, result.energy))
         theory.cleanup()
         energies.append(result.energy)
@@ -171,6 +179,14 @@ def Singlepoint_fragments(theory=None, fragments=None, stoichiometry=None, relat
         result = Singlepoint(theory=theory, fragment=frag, charge=charge, mult=mult)
         
         print("Fragment {} . Label: {} Energy: {} Eh".format(frag.formula, frag.label, result.energy))
+
+        #Preserve outputfile
+        calc_label = "Frag_" + str(frag.formula) + "_" + str(frag.charge) + "_" + str(frag.mult) + "_"
+        try:
+            shutil.copyfile(theory.filename+'.out', f'./{calc_label}.out')
+        except:
+            pass
+
         theory.cleanup()
         energies.append(result.energy)
         #Adding energy as the fragment attribute
@@ -280,6 +296,12 @@ def Singlepoint_reaction(theory=None, reaction=None, moreadfiles=None):
         result = Singlepoint(theory=theory, fragment=frag, charge=frag.charge, mult=frag.mult)
         energy = result.energy
         print("Fragment {} . Label: {} Energy: {} Eh".format(frag.formula, frag.label, energy))
+        #Preserve outputfile
+        calc_label = "Frag_" + str(frag.formula) + "_" + str(frag.charge) + "_" + str(frag.mult) + "_"
+        try:
+            shutil.copyfile(theory.filename+'.out', f'./{calc_label}.out')
+        except:
+            pass
         theory.cleanup()
         reaction.energies.append(energy)
 

--- a/modules/module_singlepoint.py
+++ b/modules/module_singlepoint.py
@@ -20,7 +20,7 @@ def Singlepoint_gradient(fragment=None, theory=None, charge=None, mult=None):
     return result
 
 #Single-point energy function
-def Singlepoint(fragment=None, theory=None, Grad=False, charge=None, mult=None):
+def Singlepoint(fragment=None, theory=None, Grad=False, charge=None, mult=None, printlevel=2):
     """Singlepoint function: runs a single-point energy calculation using ASH theory and ASH fragment.
 
     Args:
@@ -35,7 +35,8 @@ def Singlepoint(fragment=None, theory=None, Grad=False, charge=None, mult=None):
         or
         float,np.array : Energy and gradient array
     """
-    print_line_with_mainheader("Singlepoint function")
+    if printlevel >= 1:
+        print_line_with_mainheader("Singlepoint function")
     module_init_time=time.time()
     if fragment is None or theory is None:
         print(BC.FAIL,"Singlepoint requires a fragment and a theory object",BC.END)
@@ -49,19 +50,22 @@ def Singlepoint(fragment=None, theory=None, Grad=False, charge=None, mult=None):
 
     # Run a single-point energy job with gradient
     if Grad ==True:
-        print()
-        print(BC.WARNING,"Doing single-point Energy+Gradient job on fragment. Formula: {} Label: {} ".format(fragment.prettyformula,fragment.label), BC.END)
+        if printlevel >= 1:
+            print()
+            print(BC.WARNING,"Doing single-point Energy+Gradient job on fragment. Formula: {} Label: {} ".format(fragment.prettyformula,fragment.label), BC.END)
         # An Energy+Gradient calculation where we change the number of cores to 12
         energy,gradient= theory.run(current_coords=coords, elems=elems, Grad=True, charge=charge, mult=mult)
-        print("Energy: ", energy)
-        print_time_rel(module_init_time, modulename='Singlepoint', moduleindex=1)
+        if printlevel >= 1:
+            print("Energy: ", energy)
+            print_time_rel(module_init_time, modulename='Singlepoint', moduleindex=1)
         result = ASH_Results(label="Singlepoint", energy=energy, gradient=gradient, charge=charge, mult=mult)
         return result
     # Run a single-point energy job without gradient (default)
     else:
-        print()
-        print("Doing single-point Energy job on fragment. Formula: {} Label: {} ".format(fragment.prettyformula,fragment.label))
-        print(f"Charge: {charge} Mult: {mult}") #Charge/mult should have been defined so we print
+        if printlevel >= 1:
+            print()
+            print("Doing single-point Energy job on fragment. Formula: {} Label: {} ".format(fragment.prettyformula,fragment.label))
+            print(f"Charge: {charge} Mult: {mult}") #Charge/mult should have been defined so we print
         #Run
         energy = theory.run(current_coords=coords, elems=elems, charge=charge, mult=mult)
 
@@ -70,11 +74,12 @@ def Singlepoint(fragment=None, theory=None, Grad=False, charge=None, mult=None):
         if type(energy) is tuple:
             componentsdict=energy[1]
             energy=energy[0]
-
-        print("Energy: ", energy)
+        if printlevel >= 1:
+            print("Energy: ", energy)
         #Now adding total energy to fragment
         fragment.set_energy(energy)
-        print_time_rel(module_init_time, modulename='Singlepoint', moduleindex=1)
+        if printlevel >= 1:
+            print_time_rel(module_init_time, modulename='Singlepoint', moduleindex=1)
         result = ASH_Results(label="Singlepoint", energy=energy, charge=charge, mult=mult)
         return result
 


### PR DESCRIPTION
- OpenMMTheory interface: cleanup regarding PBC and non-PBC, support for implicit solvent in Modeller, modeller logic cleanup
- actregiondefine: psffile option
- DiceTheory: small cleanup, dipole moment
- PySCFTheory: Brueckner CC, CC diis iterations, FNO orbital options, pySCF CC dipole moment, MP2 option, mp2-natorbs bug, T1,D1,D2 indices printed after CC
- CFourTheory: Brueckner
- ORCATheory: improved printing
- MRCC: ASH-frozen core settings enforced
- Singlepoint_theories, Singlepoint_fragments, Singlepoint_reaction outputfiles preserved