### PR TITLE
Pcelementhardness

### DIFF
--- a/ash/interfaces/interface_xtb.py
+++ b/ash/interfaces/interface_xtb.py
@@ -81,7 +81,8 @@ class xTBTheory:
         self.theorytype="QM"
         self.analytic_hessian=False
 
-        # Hardness of pointcharge. GAM factor. Big number means PC behaviour
+        # Hardness of pointcharge. GAM factor. Big number means PC behaviour. 
+        # If hardness is set to 'elements', xtb's element-specific hardness is used (see https://xtb-docs.readthedocs.io/en/latest/pcem.html).
         self.hardness=hardness_PC
 
         # Accuracy (0.1 it quite tight)

--- a/ash/interfaces/interface_xtb.py
+++ b/ash/interfaces/interface_xtb.py
@@ -448,7 +448,11 @@ class xTBTheory:
                 print("...")
             # Create pcharge file if PC
             if PC:
-                create_xtb_pcfile_general(current_MM_coords, MMcharges, hardness=self.hardness)
+                if self.hardness == 'elements':
+                    hardness = mm_elems
+                else:
+                    hardness = [self.hardness] * len(MMcharges)
+                create_xtb_pcfile_general(current_MM_coords, MMcharges, hardness=hardness)
 
             # Run xTB (note: passing PC and Grad Booleans)
             run_xtb_SP(self.xtbdir, self.xtbmethod, coordfile, charge, mult, printlevel=self.printlevel, PC=PC, solvent=self.solvent,
@@ -963,8 +967,8 @@ def create_xtb_pcfile_general(coords,pchargelist,hardness=1000):
     #https://xtb-docs.readthedocs.io/en/latest/pcem.html
     with open('pcharge', 'w') as pcfile:
         pcfile.write(str(len(pchargelist))+'\n')
-        for p,c in zip(pchargelist,coords):
-            line = "{} {} {} {} {}".format(p, c[0], c[1], c[2], hardness)
+        for p,c,h in zip(pchargelist,coords,hardness):
+            line = "{} {} {} {} {}".format(p, c[0], c[1], c[2], h)
             pcfile.write(line+'\n')
 
 


### PR DESCRIPTION
# Motivation
When conducting MD simulations based on ASH singlepoint calculations, I needed the [element specific hardness](https://xtb-docs.readthedocs.io/en/latest/pcem.html) for the electrostatic embedding. While this might be a niche application, the required code changes are minimal and the default behavior is not changed.
# Summary of the change
If `'elements'` is given as the `hardness_PC` of the `XTBTheory` class during initialization, the atom symbols are written to the pcharge file. This allows xtb to use the element-specific hardness in the inputfile runmode.
I have changed the comment in `__init__` to explain the change, as there was no docstring to be updated.
# Testing
The changes were tested in MD simulations and the desired effect was confirmed by inspecting the `pcharge` file/observing alternated energies.