### PR TITLE
Printouts in QM/MM MD only occur if printlevel > 0

### DIFF
--- a/ash/modules/module_QMMM.py
+++ b/ash/modules/module_QMMM.py
@@ -968,7 +968,8 @@ class QMMMTheory:
 
                 self.MMenergy, self.MMgradient = self.mm_theory.run(current_coords=current_coords, qmatoms=self.qmatoms, Grad=True)
             else:
-                print("QM/MM Grad is false")
+                if self.printlevel >= 2:
+                    print("QM/MM Grad is false")
                 self.MMenergy = self.mm_theory.run(current_coords=current_coords, qmatoms=self.qmatoms)
         else:
             self.MMenergy=0
@@ -1387,7 +1388,8 @@ class QMMMTheory:
 
                 self.MMenergy, self.MMgradient= self.mm_theory.run(current_coords=current_coords, qmatoms=self.qmatoms, Grad=True)
             else:
-                print("QM/MM Grad is false")
+                if self.printlevel >= 2:
+                    print("QM/MM Grad is false")
                 self.MMenergy= self.mm_theory.run(current_coords=current_coords, qmatoms=self.qmatoms)
         else:
             self.MMenergy=0

--- a/ash/modules/module_coords.py
+++ b/ash/modules/module_coords.py
@@ -3795,13 +3795,15 @@ def check_charge_mult(charge, mult, theorytype, fragment, jobtype, theory=None, 
 
         #Note: theory needs to be set
         if charge is None or mult is None:
-            print(BC.WARNING,f"Warning: Charge/mult was not provided to {jobtype}",BC.END)
-            print("Checking if present in QM/MM object")
+            if printlevel >= 1:
+                print(BC.WARNING,f"Warning: Charge/mult was not provided to {jobtype}",BC.END)
+                print("Checking if present in QM/MM object")
             if theory.qm_charge != None and theory.qm_mult != None:
-                print("Found qm_charge and qm_mult attributes.")
                 charge=theory.qm_charge
                 mult=theory.qm_mult
-                print(f"Using charge={charge} and mult={mult}")
+                if printlevel >= 1:
+                    print("Found qm_charge and qm_mult attributes.")
+                    print(f"Using charge={charge} and mult={mult}")
             elif fragment.charge != None and fragment.mult != None:
                 print(BC.WARNING,"Fragment contains charge/mult information: Charge: {} Mult: {} Using this instead".format(fragment.charge,fragment.mult), BC.END)
                 print(BC.WARNING,"Make sure this is what you want!", BC.END)


### PR DESCRIPTION
# Motivation
I have used ASH a lot in QM/MM MD simulations through the interface of the [`adaptive_sampling`](https://github.com/ochsenfeld-lab/adaptive_sampling) package. However, my log files got cluttered with statements of the Singlepoint calculations, even at `printlevel=0`.  With the changes, no printout occurs from the Singlepoint calculations if all theories and fragments have `printlevel=0`.
As the default `printlevel` is higher, this does not change the standard behavior.

I also did not want to always write results to disk, but I have seen that you have already made it optional in the meantime : )
# Changes
Statements about finding `qm_charge` and `qm_mult` are only shown for `printlevel>=1`. 
`Grad is false`-message in QM/MM is only shown if `printlevel>=2`