### PR TITLE
Fix charge/multiplicity forwarding in calc_surface

### DIFF
--- a/ash/modules/module_surface_new.py
+++ b/ash/modules/module_surface_new.py
@@ -406,7 +406,7 @@ def calc_surface(
                         optimizerobj.Hess_inv = None
 
                 #Running optimizer object, passing theory, fragment, constraints and possible extra kws
-                result = optimizerobj.run(theory=theory,fragment=fragment, constraints=allconstraints, **extraoopt_run_kws)
+                result = optimizerobj.run(theory=theory,fragment=fragment, constraints=allconstraints, charge=charge, mult=mult, **extraoopt_run_kws)
 
                 #if pointcount == 2:
                 #    print("2nd point optimization result:", result)
@@ -1488,7 +1488,7 @@ def _preset_geometry_restraint(fragment, RC_list, rc_values, optimizerobj,
     preset_args = {k: v for k, v in opt_arguments.items()
                    if k not in ('constraints', 'constrainvalue')}
     # Optimizing with restraint theory, passing extraconstraints as contraints if present
-    optimizerobj.run(theory=restraint_theory,fragment=fragment, constraints=extraconstraints, **extraoopt_run_kws)
+    optimizerobj.run(theory=restraint_theory,fragment=fragment, constraints=extraconstraints, charge=charge, mult=mult, **extraoopt_run_kws)
 
     #optimizer(
     #    fragment=fragment, theory=restraint_theory, constraints=extraconstraints,


### PR DESCRIPTION
## Summary

`calc_surface()` accepts `charge` and `mult` arguments, but these values were not forwarded to `optimizerobj.run()` during relaxed scans.

As a result, geomeTRIC could fail with:

```
Warning: Charge/mult was not provided to geomeTRICOptimizer
Checking if present in QM/MM object
No charge/mult information present in fragment either. Exiting.
```

Users currently have to manually set:

```python
frag.charge = charge
frag.mult = mult
```

in their input scripts as a workaround, even when `calc_surface(charge=..., mult=...)` is already used.

## Fix

This PR forwards `charge` and `mult` explicitly to `optimizerobj.run()` in two places:

1. Standard relaxed scan path (`calc_surface`)
2. Preset geometry restraint path (`_preset_geometry_restraint`)

## Rationale

This preserves the documented `calc_surface()` API behavior and avoids requiring manual `Fragment` charge/multiplicity assignment in user scripts.

The change is backward compatible and only affects optimizer invocation.