### PR TITLE
Fix DLFIND_optimizer crashes with active regions

### DIFF
--- a/ash/interfaces/interface_dlfind.py
+++ b/ash/interfaces/interface_dlfind.py
@@ -525,7 +525,7 @@ class DLFIND_optimizerClass:
                 self.frozenatoms = self.frozenatoms+frozenatoms_xyz
                 print("frozenatoms_z:", frozenatoms_z)
         if self.actatoms is not None:
-            print_if_level("Actatoms provided:", self.actatoms)
+            print_if_level(f"Actatoms provided: {self.actatoms}", self.printlevel, 2)
 
             if self.PBC:
                 print("PBC detected. Adding 4 dummy atoms to actatoms if not already present")


### PR DESCRIPTION
Running DLFIND_optimizer with actatoms crashes during setup:

`TypeError: print_if_level() missing 1 required positional argument: 'refprintlevel'`

The actatoms list is being passed where the printlevel arg should go, and the threshold arg is missing:

Changed in `interface_dlfind.py`:
`print_if_level("Actatoms provided:", self.actatoms)`
to
`print_if_level(f"Actatoms provided: {self.actatoms}", self.printlevel, 2)`