### PR TITLE
Fix OpenFF option in small_molecule_parameterizer

### DIFF
--- a/ash/interfaces/interface_OpenMM.py
+++ b/ash/interfaces/interface_OpenMM.py
@@ -6337,7 +6337,7 @@ def small_molecule_parameterizer(charge=None, xyzfile=None, pdbfile=None, molfil
         import openff
 
         from openmmforcefields.generators import SMIRNOFFTemplateGenerator
-        smirnoff = SMIRNOFFTemplateGenerator(molecules=molecule)
+        smirnoff = SMIRNOFFTemplateGenerator(molecules=molecule, forcefield=openff_file)
 
         forcefield = ForceField('amber/protein.ff14SB.xml', 'amber/tip3p_standard.xml', 'amber/tip3p_HFE_multivalent.xml')
         # Register the SMIRNOFF template generator


### PR DESCRIPTION
The openff_file argument was never passed to SMIRNOFFTemplateGenerator, so forcefield_option="OpenFF" crashed with "A SMIRNOFF force field name, path, file object, or XML string must be provided". This passes it through, like the GAFF branch does with gaffversion. Tested on isobutyraldehyde.