### PR TITLE
Fix OpenMM tutorial failure from ligand residue mismatch and unstable post-warm-up coordinates

### DIFF
--- a/ash/interfaces/interface_OpenMM.py
+++ b/ash/interfaces/interface_OpenMM.py
@@ -5040,6 +5040,19 @@ def OpenMM_box_equilibration(fragment=None, theory=None, datafilename="nptsim.cs
                         datafilename=datafilename, trajectory_file_option=trajectory_file_option,
                         dummyatomrestraint=dummyatomrestraint, solute_indices=solute_indices,
                         barostat_frequency=barostat_frequency)
+    # Sanity-check coordinates before the first NPT cycle by minimizing a temporary simulation.
+    # This avoids carrying potentially unstable positions/velocities from a preceding warm-up into NPT.
+    import openmm
+    try:
+        tmp_simulation = md.openmmobject.create_simulation()
+        md.openmmobject.set_positions(fragment.coords, tmp_simulation)
+        tmp_simulation.minimizeEnergy(maxIterations=200, tolerance=1.0)
+        state = tmp_simulation.context.getState(getPositions=True)
+        minimized_coords = state.getPositions(asNumpy=True).value_in_unit(openmm.unit.angstrom)
+        fragment.coords = minimized_coords
+        md.positions = minimized_coords
+    except Exception as e:
+        print("OpenMM_box_equilibration pre-minimization failed:", type(e).__name__, e)
     restart=False
     #while volume_std >= volume_threshold and density_std >= density_threshold:
     for i in range(max_NPT_cycles):

--- a/ash/interfaces/interface_openbabel.py
+++ b/ash/interfaces/interface_openbabel.py
@@ -201,7 +201,7 @@ def writepdb_with_connectivity(file):
     return os.path.splitext(file)[0]+'_withcon.pdb'
 
 #Function to read in XYZ-file (small molecule) and create PDB-file with CONECT lines (geometry needs to be sensible)
-def xyz_to_pdb_with_connectivity(file, resname="UNL"):
+def xyz_to_pdb_with_connectivity(file, resname="LIG"):
     print("xyz_to_pdb_with_connectivity function:")
     #OpenBabel
     try:


### PR DESCRIPTION
When following the Explicit Solvation tutorial with OpenMM, NaN errors were encountered due to (1) mismatched ligand naming from the OpenBabel PDB conversion, and (2) unstable initial coordinates before box equilibration.

For Issue (1), the ligand residue name is standardized to LIG across the OpenMM workflow to avoid mismatches with force-field definitions.

For Issue (2), a short pre-minimization step is added before the first NPT cycle in OpenMM_box_equilibration to recover from unstable coordinates or velocities carried forward from earlier stages.