### PR TITLE
fix: stop PySCF runs before using unconverged states

### DIFF
--- a/ash/interfaces/interface_pyscf.py
+++ b/ash/interfaces/interface_pyscf.py
@@ -2569,6 +2569,14 @@ class PySCFTheory:
 
         #Grid printing
         scf_result = mf.run(dm)
+        # max_cycle<=0 is an intentional non-SCF evaluation used by scf_noiter.
+        if not scf_result.converged and mf.max_cycle > 0:
+            ashexit(
+                errormessage=(
+                    f"PySCF SCF did not converge (max_cycle={mf.max_cycle}). "
+                    "Refusing to continue with an unconverged electronic state."
+                )
+            )
         #Grid
         if 'KS' in self.scf_type:
             try:

--- a/ash/tests/test_pyscf_scf_convergence.py
+++ b/ash/tests/test_pyscf_scf_convergence.py
@@ -1,0 +1,145 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
+import pytest
+
+from ash.interfaces.interface_pyscf import PySCFTheory
+
+
+class FakeRHF:
+    def __init__(self, *, converged, max_cycle=50):
+        self.converged = converged
+        self.max_cycle = max_cycle
+        self.e_tot = -75.0
+        self.mo_occ = np.array([2.0])
+        self.make_rdm1_calls = 0
+        self.nuc_grad_method_calls = 0
+        self.grad_hcore_mm_calls = 0
+        self.grad_nuc_mm_calls = 0
+
+    def run(self, dm):
+        return self
+
+    def make_rdm1(self):
+        self.make_rdm1_calls += 1
+        return np.array([[2.0]])
+
+    def nuc_grad_method(self):
+        self.nuc_grad_method_calls += 1
+        return FakeGradient(self)
+
+
+class FakeGradient:
+    def __init__(self, mf):
+        self.mf = mf
+
+    def kernel(self):
+        return np.array([[0.0, 0.0, 0.0]])
+
+    def grad_hcore_mm(self, dm):
+        self.mf.grad_hcore_mm_calls += 1
+        return np.array([[0.0, 0.0, 0.0]])
+
+    def grad_nuc_mm(self):
+        self.mf.grad_nuc_mm_calls += 1
+        return np.array([[0.0, 0.0, 0.0]])
+
+
+def install_fake_pyscf(monkeypatch):
+    pyscf_module = ModuleType("pyscf")
+    pyscf_dft_module = ModuleType("pyscf.dft")
+    pyscf_dft_module.rks = SimpleNamespace(RKS=type("FakeRKS", (), {}))
+    pyscf_module.dft = pyscf_dft_module
+    pyscf_module.scf = SimpleNamespace(hf=SimpleNamespace(RHF=FakeRHF))
+    monkeypatch.setitem(sys.modules, "pyscf", pyscf_module)
+    monkeypatch.setitem(sys.modules, "pyscf.dft", pyscf_dft_module)
+
+
+def make_theory(mf):
+    theory = PySCFTheory.__new__(PySCFTheory)
+    theory.printlevel = 0
+    theory.mf = mf
+    theory.scf_type = "RHF"
+    theory.functional = None
+    theory.platform = "CPU"
+    theory.periodic = False
+    return theory
+
+
+def test_run_scf_aborts_before_density_for_unconverged_result(monkeypatch):
+    install_fake_pyscf(monkeypatch)
+    mf = FakeRHF(converged=False)
+    theory = make_theory(mf)
+
+    with pytest.raises(SystemExit):
+        theory.run_SCF()
+
+    assert mf.make_rdm1_calls == 0
+
+
+def test_run_scf_allows_explicit_zero_cycle_evaluation(monkeypatch):
+    install_fake_pyscf(monkeypatch)
+    mf = FakeRHF(converged=False)
+    theory = make_theory(mf)
+
+    result = theory.run_SCF(max_cycle=0)
+
+    assert result is mf
+    assert mf.max_cycle == 0
+    assert mf.make_rdm1_calls == 1
+    np.testing.assert_array_equal(theory.dm, np.array([[2.0]]))
+
+
+def test_run_scf_allows_explicit_negative_cycle_evaluation(monkeypatch):
+    install_fake_pyscf(monkeypatch)
+    mf = FakeRHF(converged=False, max_cycle=-1)
+    theory = make_theory(mf)
+
+    result = theory.run_SCF()
+
+    assert result is mf
+    assert mf.make_rdm1_calls == 1
+
+
+def test_actualrun_aborts_before_gradient_and_pc_gradient_for_unconverged_scf(monkeypatch):
+    install_fake_pyscf(monkeypatch)
+    mf = FakeRHF(converged=False)
+    theory = make_theory(mf)
+    theory.SCF = True
+    theory.verbose_setting = 0
+    theory.write_chkfile_name = None
+    theory.BS = False
+    theory.setup_guess = lambda: None
+    theory.run_stability_analysis = lambda: None
+    theory.do_pop_analysis = False
+    theory.get_dipole_moment = lambda: None
+    theory.dispersion = None
+    theory.NMF = False
+    theory.losc = False
+    theory.postSCF = False
+    theory.PC_gradient_code = "new"
+
+    with pytest.raises(SystemExit):
+        theory.actualrun(
+            Grad=True,
+            PC=True,
+            current_MM_coords=np.array([[1.0, 0.0, 0.0]]),
+            MMcharges=np.array([1.0]),
+        )
+
+    assert mf.nuc_grad_method_calls == 0
+    assert mf.grad_hcore_mm_calls == 0
+    assert mf.grad_nuc_mm_calls == 0
+
+
+def test_run_scf_preserves_density_for_converged_result(monkeypatch):
+    install_fake_pyscf(monkeypatch)
+    mf = FakeRHF(converged=True)
+    theory = make_theory(mf)
+
+    result = theory.run_SCF()
+
+    assert result is mf
+    assert mf.make_rdm1_calls == 1
+    np.testing.assert_array_equal(theory.dm, np.array([[2.0]]))


### PR DESCRIPTION

## Summary

- fail closed immediately when a positive-cycle PySCF/GPU4PySCF SCF run reports `converged=False`
- prevent unconverged densities from reaching gradient and QM/MM force evaluation
- preserve the intentional non-iterative `max_cycle <= 0` behavior, including `scf_noiter=True`
- add focused regression tests for the guard, non-iterative compatibility, downstream gradient blocking, and the converged path

## Why

The previous code continued after `mf.run(dm)` regardless of the backend convergence flag. In a QM/MM MD workflow this could return forces from an unconverged electronic state to OpenMM.

Fixes #514.

## Validation

```bash
/opt/anaconda3/bin/python -m pytest ash/tests/test_pyscf_scf_convergence.py -q
```

```text
5 passed
```

A real PySCF 2.8.0 CPU smoke test also confirmed that a deliberately unconverged positive-cycle calculation is blocked and `max_cycle=0` remains usable.

Separately, the user reported that the patched guard stopped the original laboratory GPU/QM/MM failure at step 0 before the QMMM return or MD integration.

## Known limitation and follow-up

The triggering case was a user-reported B3LYP/def2-TZVP GPU4PySCF QM/MM calculation with 8,988 MM point charges in electrostatic embedding. The SCF did not converge with `max_cycle=50` and remained unconverged at `max_cycle=200`. This PR makes that failure safe; it does not make the electronic state converge or establish the point-charge count as the sole cause.

A separate effort will evaluate reuse of a trusted density or checkpoint from the preceding converged MD step and staged adaptive recovery with DIIS, damping, level shifting, and SOSCF. That work will be validated and proposed independently.

## Compatibility

`max_cycle <= 0` remains allowed because PySCF uses that range for non-iterative evaluation and ASH intentionally uses `max_cycle=0` for `scf_noiter=True`. Normal converged calculations are unchanged.

## Scope boundary

This PR only prevents unsafe use of an unconverged state. It intentionally does not add adaptive SCF convergence logic or change solver parameters.
