### PR TITLE
xTB-based QM/MM CP2K jobs

### DIFF
--- a/ash/interfaces/interface_CP2K.py
+++ b/ash/interfaces/interface_CP2K.py
@@ -366,12 +366,14 @@ class CP2KTheory:
         #Case: QM/MM CP2K job
         if PC is True:
             print("PC true")
-            if self.coupling == 'COULUMB':
+            if self.coupling == 'COULOMB' and self.basis_method != 'XTB':
                 print("Error: Coupling option is COULOMB (regular electrostatic embedding)")
                 print("This option is not compatible with CP2K GPW/GAPW option which is the main reason to use CP2K")
                 print("Set coupling to GAUSS or S-WAVE instead")
                 print("Exiting")
                 ashexit()
+            elif self.coupling == 'COULOMB' and self.basis_method == 'XTB':
+                print("Using COULOMB (regular electrostatic embedding) with xTB!")
             elif self.coupling == 'GAUSS':
                 print("Using Gaussian GEEP embedding")
                 print("Number of Gaussians used:", self.GEEP_num_gauss)


### PR DESCRIPTION
**Summary**
This allows the usage of regular electrostatic embedding (COULOMB, fixed typo) in QM/MM CP2K jobs with an xTB-level description of the QM region.

**Why**
CP2K has no implementation of GAUSS embedding (GEEP) for semi-empirical methods; tested with _CP2K 2026.2_. This prevented the execution of xTB-based QM/MM CP2K jobs.

> QMMM| Information on the QM/MM Electrostatic Potential: 
> GAUSS or SWAVE QM/MM electrostatic coupling not implemented for DFTB.